### PR TITLE
Changed test for megabytes in V command

### DIFF
--- a/MON1.ASM
+++ b/MON1.ASM
@@ -3620,8 +3620,8 @@ ENDJ1     LEA       VER_MSG,A1      ; 'QDOS Version: ' message
           LSR.L     #8,D1           ; Divide by 1024 - part 1
           LSR.L     #2,D1           ; Continued
           MOVEQ     #'K',D7         ; Assume Kilobytes
-          BTST      #15,D1          ; Have we gone into megabytes?
-          BEQ.S     V_FREE          ; No, skip
+          CMPI.L    #$7FFF,D1       ; Have we gone into megabytes?
+          BLE.S     V_FREE          ; No, skip
           MOVEQ     #'M',D7         ; Yes, flag Megabytes
           LSR.L     #8,D1           ; Divide by 1024 again
           LSR.L     #2,D1


### PR DESCRIPTION
Hi Jan, I followed your hint and changed the test of bit 15 to a full blooded CMPI.L #$7FFF,D1 to ensure that we were not in the Megabyte range of free memory. Interestingly enough, when I tested before changing, with 128 Mb, I got the correct answer of 124 MB free.

It now works for 96MB startup and gives 92MB free immediately after starting the system and 
only the monitor (and QRAM2) is running.

Please pull my issue_3 branch again, at your convenience, thanks. This relates to issue #3 as previously raised.

Cheers,
Norm.